### PR TITLE
[1.18] Added missing coal fragment as a fuel

### DIFF
--- a/src/main/java/ca/rttv/malum/mixin/AbstractFurnaceBlockEntityMixin.java
+++ b/src/main/java/ca/rttv/malum/mixin/AbstractFurnaceBlockEntityMixin.java
@@ -36,6 +36,7 @@ abstract class AbstractFurnaceBlockEntityMixin {
         addFuel(map, BLAZING_QUARTZ_FRAGMENT, 200);
         addFuel(map, BLOCK_OF_BLAZING_QUARTZ, 14400);
         addFuel(map, CHARCOAL_FRAGMENT, 200);
+        addFuel(map, COAL_FRAGMENT, 200);
     }
 
     @Shadow


### PR DESCRIPTION
Coal fragments currently aren't burnable, this fixes that